### PR TITLE
feat:(getRender) simplify default export

### DIFF
--- a/src/__tests__/buildWiring.test.js
+++ b/src/__tests__/buildWiring.test.js
@@ -1,7 +1,7 @@
 import {cleanup} from '@testing-library/react'
 import React from 'react'
 import {combine} from '../helpers'
-import buildWiring from '../index'
+import {getRender} from '../index'
 import CounterList from '../CounterList'
 
 afterEach(() => {
@@ -159,8 +159,7 @@ const wiringWithoutSerialize = {
 
 describe('buildWiring helper', () => {
   test('should correctly handler serializers', async () => {
-    const getRender = buildWiring(wiring)
-    const render = getRender(['counterContainer'])
+    const render = getRender(wiring)
     const {findCounterList} = render(fixture)
     const {counterContainer, findCounter} = await findCounterList()
     const assertFirstRow = async () => {
@@ -218,8 +217,7 @@ describe('buildWiring helper', () => {
   })
   test('should be possible to call manually call serialize', async () => {
     jest.spyOn(console, 'log')
-    const getRender = buildWiring(wiring)
-    const render = getRender(['counterContainer'])
+    const render = getRender(wiring)
     const {findCounterList, serialize} = render(fixture)
     const {counterContainer} = await findCounterList()
     serialize(counterContainer)
@@ -232,8 +230,7 @@ describe('buildWiring helper', () => {
   })
   describe('if wiring is provided without a serializer', () => {
     test('the provided string should be undefined', async () => {
-      const getRender = buildWiring(wiringWithoutSerialize)
-      const render = getRender(['counterContainer'])
+      const render = getRender(wiringWithoutSerialize)
       const {findCounterContainer} = render(fixture)
       const {counterContainer} = await findCounterContainer()
       expect(counterContainer).toMatchSnapshot('on initial render')

--- a/src/__tests__/customQueries.test.js
+++ b/src/__tests__/customQueries.test.js
@@ -1,6 +1,6 @@
 import React, {Fragment, useState} from 'react'
 import {queryHelpers} from '@testing-library/react'
-import buildWiring from '../index'
+import {getRender} from '../index'
 const {queryAllByAttribute} = queryHelpers
 const Icon = ({name, onClick}) => <span onClick={onClick} xlinkHref={name} />
 
@@ -119,8 +119,7 @@ const wiring = {
 
 describe('Custom Queries', () => {
   test('custom queries should work with all built in functions', async () => {
-    const getRender = buildWiring(wiring, config)
-    const render = getRender(['iconControls'])
+    const render = getRender(wiring, config)
     const {findIconControls} = render(fixture)
     const {
       showIcons,

--- a/src/__tests__/defaultGlobalFunctions.test.js
+++ b/src/__tests__/defaultGlobalFunctions.test.js
@@ -1,6 +1,6 @@
 import React, {useState} from 'react'
 import {cleanup} from '@testing-library/react'
-import buildWiring from '../index'
+import {getRender} from '../index'
 
 afterEach(cleanup)
 
@@ -33,8 +33,7 @@ const blurWiring = {
 
 describe('Default functions returned with all wiring', () => {
   test('focus, blur and typeInto, should behave as expected', async () => {
-    const getRender = buildWiring(blurWiring)
-    const render = getRender(['input'])
+    const render = getRender(blurWiring)
     const {findInput} = render(blurFixture)
     const {input, blur, focus, typeInto} = await findInput()
     expect(input).toMatchSnapshot('initial render')

--- a/src/__tests__/types.test.js
+++ b/src/__tests__/types.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import buildWiring from '../index'
+import {getRender} from '../index'
 
 afterEach(() => {
   const body = document.body
@@ -144,8 +144,7 @@ const multiLevelFixture = (
 describe('Typed Wiring', () => {
   describe('if providing a type without extend', () => {
     test('should just not extend anything', async () => {
-      const getRender = buildWiring(wiring)
-      const render = getRender(['list'])
+      const render = getRender(wiring)
       const {findList} = render(typeWithoutExtendFixture)
       const {list} = await findList()
       expect(list).toMatchSnapshot('on initial render')
@@ -153,8 +152,7 @@ describe('Typed Wiring', () => {
   })
   describe('if providing a type without children', () => {
     test('should not add any custom children', async () => {
-      const getRender = buildWiring(wiring)
-      const render = getRender(['list'])
+      const render = getRender(wiring)
       const {findList} = render(typeWithoutChildrenFixture)
       const {list} = await findList()
       expect(list).toMatchSnapshot('on initial render')
@@ -162,8 +160,7 @@ describe('Typed Wiring', () => {
   })
   describe('if a typed wiring does not provide serialize', () => {
     test('undefined should be passed into the child type serializers', async () => {
-      const getRender = buildWiring(typedWiringWithoutSerialize)
-      const render = getRender(['list'])
+      const render = getRender(typedWiringWithoutSerialize)
       const {findList} = render(typeWithoutExtendFixture)
       const {list} = await findList()
       expect(list).toMatchSnapshot('on initial render')
@@ -171,8 +168,7 @@ describe('Typed Wiring', () => {
   })
   describe('if providing a type that has further types beneath in', () => {
     test('extend, serialize, and children should chain through', async () => {
-      const getRender = buildWiring(multiLevelTypeWiring)
-      const render = getRender(['list'])
+      const render = getRender(multiLevelTypeWiring)
       const {findList} = render(multiLevelFixture)
       const {list} = await findList()
       expect(list).toMatchSnapshot('on initial render')

--- a/src/index.js
+++ b/src/index.js
@@ -288,7 +288,7 @@ const matchesTestId = (object, testId) => {
   )
 }
 
-export default (wiring, config = {}) => wiringKeys => {
+export const getRender = (wiring, config = {}) => {
   const {customFunctions = {}, customQueries = {}} = config
   const {global = () => ({}), withinElement = funcs => funcs} = customFunctions
   const {children, extend} = wiring
@@ -310,7 +310,7 @@ export default (wiring, config = {}) => wiringKeys => {
       ),
     )
   }
-  wiringKeys.forEach(key => {
+  Object.keys(wiring.children).forEach(key => {
     expect.addSnapshotSerializer({
       test: val => matchesTestId(val, wiring.children[key].findValue),
       print: val => {


### PR DESCRIPTION
Documenting this function made it clear that this was a little bit more complicated that it needs to be.  Now it's just a single step to create a render for test.  Also, we're changing to a named export to make it more explicit. 